### PR TITLE
Check asset comparison errors

### DIFF
--- a/yandexgpt_service.py
+++ b/yandexgpt_service.py
@@ -196,8 +196,9 @@ Format responses professionally with clear sections, bullet points, and relevant
             r'\bsberbank\b': 'SBER.MOEX',
             r'\bгазпром\b': 'GAZP.MOEX',
             r'\bлукойл\b': 'LKOH.MOEX',
-            r'\bbitcoin\b': 'BTC.CC',
-            r'\beth\b': 'ETH.CC',
+            # Use Yahoo-style crypto tickers that Okama is more likely to support
+            r'\bbitcoin\b': 'BTC-USD',
+            r'\beth\b': 'ETH-USD',
             r'\bgold\b': 'XAU.COMM',
             r'\bsilver\b': 'XAG.COMM',
             r'\boil\b': 'BRENT.COMM',


### PR DESCRIPTION
Implement crypto symbol resolution and update NLP mapping to prevent "asset not found" errors for BTC.CC/ETH.CC.

The original error "Errno BTC.CC is not found in the database" occurred because the `okama` library did not recognize crypto symbols in the `.CC` format. This PR addresses the issue by introducing a symbol resolution fallback in the comparison service to convert `.CC` symbols to supported formats (e.g., `BTC-USD`) and by updating the NLP service to generate these supported formats directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-499602b3-b6c6-47d6-933b-77125f01b2c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-499602b3-b6c6-47d6-933b-77125f01b2c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

