### PR TITLE
Check usdt namespace for btc and eth assets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests>=2.31.0
 Pillow>=10.0.0
 plotly>=5.15.0
 kaleido>=0.2.1
+yfinance>=0.2.40


### PR DESCRIPTION
Implement `yfinance` fallback for `.CC` crypto symbols and remove invalid `.USDT`/`.USD` fallbacks to resolve namespace errors and enable crypto asset comparison.

The original issue stemmed from Okama's strict namespace validation, where suffixes like `.USDT` or `.USD` were incorrectly treated as namespaces during symbol resolution for `.CC` crypto assets. Additionally, Okama does not natively support `.CC` symbols. This PR addresses both by removing the problematic fallbacks and introducing `yfinance` as a robust alternative for fetching and computing metrics for `.CC` crypto assets.

---
<a href="https://cursor.com/background-agent?bcId=bc-10fc9de8-d4a7-4034-98a2-e2a152ad9d56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10fc9de8-d4a7-4034-98a2-e2a152ad9d56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

