### PR TITLE
Check crypto asset comparison dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ requests>=2.31.0
 Pillow>=10.0.0
 plotly>=5.15.0
 kaleido>=0.2.1
+yfinance>=0.2.38
 
 # Optional: Web service dependencies (only if needed)
 # Flask>=2.3.0


### PR DESCRIPTION
Add `yfinance` to `requirements.txt` to enable crypto asset comparison.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa736c15-9602-4737-96f4-144f088d29f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa736c15-9602-4737-96f4-144f088d29f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

