### PR TITLE
Diagnose and fix deployment port binding error

### DIFF
--- a/config_files/render.yaml
+++ b/config_files/render.yaml
@@ -1,9 +1,9 @@
 # Render configuration for Okama Finance Bot v2.0
-# This service handles port scanning briefly, then runs as a background worker
+# Background worker (no HTTP port required)
 
 services:
-  # Service that satisfies port scan then becomes background worker
-  - type: web
+  # Background worker service
+  - type: worker
     name: okama-finance-bot
     env: python
     plan: starter
@@ -11,10 +11,9 @@ services:
     # Build configuration
     buildCommand: pip install -r requirements.txt
     
-    # Start command - first satisfies port scan, then runs background worker
+    # Start command
     startCommand: python scripts/start_bot.py
     
-    # Port configuration for Render port scanning
     envVars:
       # Python configuration
       - key: PYTHON_VERSION
@@ -28,9 +27,7 @@ services:
       - key: RENDER
         value: "true"
       - key: RENDER_SERVICE_TYPE
-        value: "web"
-      - key: PORT
-        value: "8000"
+        value: "worker"
       
       # Bot configuration (set these in Render dashboard)
       - key: TELEGRAM_BOT_TOKEN


### PR DESCRIPTION
Configure Render service as a background worker and add an optional HTTP health server to resolve deployment timeouts.

The Render deployment failed due to a "Port scan timeout reached" error because no open ports were detected. This PR primarily configures the Render service as a background worker, which does not require an open port. Additionally, a lightweight HTTP health server is added to `bot.py` and `scripts/start_bot.py` to bind to the `$PORT` environment variable if present, ensuring that the service will pass Render's port scan even if configured as a web service.

---
<a href="https://cursor.com/background-agent?bcId=bc-dccb00f3-2c47-4f61-b117-ebb321858aee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dccb00f3-2c47-4f61-b117-ebb321858aee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

