### PR TITLE
Исправить ошибку разбора запроса пользователя

### DIFF
--- a/services/intent_parser_enhanced.py
+++ b/services/intent_parser_enhanced.py
@@ -296,14 +296,24 @@ class EnhancedIntentParser:
         okama_matches = re.findall(okama_pattern, text, re.IGNORECASE)
         assets.extend(okama_matches)
         
-        # Ищем обычные тикеры (без точки)
+        # Ищем обычные тикеры (без точки), исключая части уже найденных okama-тикеров
         ticker_pattern = r'\b([A-Z]{1,5})\b'
         ticker_matches = re.findall(ticker_pattern, text, re.IGNORECASE)
         
-        # Фильтруем тикеры, которые не являются словами
+        # Собираем множество всех частей, входящих в уже найденные okama-тикеры, чтобы не дублировать
+        okama_parts = set()
+        for m in okama_matches:
+            parts = m.upper().split('.')
+            okama_parts.update(parts)
+        
+        # Фильтруем тикеры, которые не являются словами валют и не являются частями уже найденных okama-тикеров
         for ticker in ticker_matches:
-            if ticker.lower() not in ['usd', 'eur', 'rub', 'cny', 'gbp', 'jpy']:
-                assets.append(ticker)
+            upper_ticker = ticker.upper()
+            if upper_ticker.lower() in ['usd', 'eur', 'rub', 'cny', 'gbp', 'jpy']:
+                continue
+            if upper_ticker in okama_parts:
+                continue
+            assets.append(ticker)
         
         # Ищем названия активов через алиасы
         text_lower = text.lower()


### PR DESCRIPTION
Fix incorrect parsing of Okama-formatted assets by preventing their constituent parts from being re-identified as separate tickers.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ed3ecc4-afc3-4d59-b5c8-e65ecf560a98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ed3ecc4-afc3-4d59-b5c8-e65ecf560a98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

