### PR TITLE
Fix portfolio creation and daily chart errors

### DIFF
--- a/services/report_builder_enhanced.py
+++ b/services/report_builder_enhanced.py
@@ -465,7 +465,14 @@ class EnhancedReportBuilder:
             fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
             
             # Стоимость портфеля
-            ax1.plot(portfolio_prices.index, portfolio_prices.values, 
+            try:
+                idx = portfolio_prices.index
+                # Безопасная конвертация PeriodIndex -> Timestamp
+                if hasattr(idx, 'to_timestamp'):
+                    idx = idx.to_timestamp()
+            except Exception:
+                idx = portfolio_prices.index
+            ax1.plot(idx, portfolio_prices.values,
                     color=self.colors[0], linewidth=2)
             ax1.set_title('Стоимость портфеля', fontsize=14, fontweight='bold')
             ax1.set_ylabel(f'Стоимость ({currency})', fontsize=12)


### PR DESCRIPTION
Fix `float(Period)` error in portfolio plotting and harden chart smoothing for date-like indices.

The `float() argument must be a string or a real number, not 'Period'` error occurred because `matplotlib`'s plotting functions or underlying numerical operations attempted to cast a pandas `Period` object directly to a float. This PR addresses this by explicitly converting `PeriodIndex` to `Timestamp` before plotting portfolio data. Additionally, chart smoothing logic was improved to convert various date-like indices (Period, Datetime) to numeric timestamps for interpolation, then back to datetime objects, preventing similar type conversion errors in daily charts.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d6e4ccd-ee5c-4f2c-93b6-64b0f44808f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d6e4ccd-ee5c-4f2c-93b6-64b0f44808f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

