### PR TITLE
Fix monte carlo chart style error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2693,16 +2693,28 @@ class OkamaFinanceBot:
         try:
             self.logger.info(f"Creating Monte Carlo forecast chart for portfolio: {symbols}")
             
-            # Create Monte Carlo forecast using okama
-            # y.plot_forecast_monte_carlo(distr="norm", years=5, n=20)
-            fig = chart_styles.create_figure()
-            chart_styles.apply_base_style(fig)
-            
-            # Generate Monte Carlo forecast
+            # Generate Monte Carlo forecast (okama creates the figure)
             forecast_data = portfolio.plot_forecast_monte_carlo(distr="norm", years=5, n=20)
-            
-            # Get the current figure from matplotlib
+
+            # Get the current figure from matplotlib (created by okama)
             current_fig = plt.gcf()
+
+            # Apply chart styles to the current figure
+            if current_fig.axes:
+                ax = current_fig.axes[0]
+                chart_styles.apply_base_style(current_fig, ax)
+
+                # Customize the chart
+                ax.set_title(
+                    f'Прогноз Monte Carlo\n{", ".join(symbols)}',
+                    fontsize=chart_styles.title_config['fontsize'],
+                    fontweight=chart_styles.title_config['fontweight'],
+                    pad=chart_styles.title_config['pad'],
+                    color=chart_styles.title_config['color']
+                )
+
+                # Add copyright signature
+                chart_styles.add_copyright(ax)
             
             # Save the figure
             img_buffer = io.BytesIO()


### PR DESCRIPTION
Fix `apply_base_style` call for Monte Carlo charts to include the `ax` argument and apply proper styling.

The `ChartStyles.apply_base_style()` method was missing the `ax` argument when called for Monte Carlo charts, leading to an error. The fix now retrieves the figure and its axes after `okama` generates the chart, then correctly applies the base style, title, and copyright to the chart's axes.

---
<a href="https://cursor.com/background-agent?bcId=bc-534413c4-f583-4cb5-8501-79eb741211e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-534413c4-f583-4cb5-8501-79eb741211e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

