### PR TITLE
Handle asset comparison and portfolio creation errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,6 +11,8 @@ from typing import Dict, List, Optional, Any
 
 # Third-party imports
 import matplotlib
+import pandas as pd
+import okama as ok
 
 # Configure matplotlib backend for headless environments (CI/CD)
 if os.getenv('DISPLAY') is None and os.getenv('MPLBACKEND') is None:

--- a/reports/COMPARE_PORTFOLIO_IMPORTS_FIX_REPORT.md
+++ b/reports/COMPARE_PORTFOLIO_IMPORTS_FIX_REPORT.md
@@ -1,0 +1,33 @@
+## Compare/Portfolio Imports Fix Report
+
+### Summary
+Fixed NameError exceptions when handling `/compare` and portfolio creation flows:
+- `name 'pd' is not defined`
+- `name 'ok' is not defined`
+
+### Root Cause
+- `bot.py` used `pandas` (`pd`) utilities and `okama` (`ok`) symbols without importing them.
+- `services/analysis_engine_enhanced.py` referenced `pd.DataFrame` without importing `pandas`.
+
+### Changes
+- Added imports to `bot.py`:
+  - `import pandas as pd`
+  - `import okama as ok`
+- Added import to `services/analysis_engine_enhanced.py`:
+  - `import pandas as pd`
+
+### Files Updated
+- `bot.py`
+- `services/analysis_engine_enhanced.py`
+
+### Impact
+- `/compare` and portfolio-related commands no longer fail with NameError for `pd` or `ok`.
+- No behavioral changes beyond resolving the exceptions.
+
+### Validation
+- Grepped the codebase for `pd.` and `ok.` usages to ensure corresponding imports are present.
+- Confirmed `services/*` already import `okama` where needed.
+
+### Follow-ups
+- None required.
+

--- a/services/analysis_engine_enhanced.py
+++ b/services/analysis_engine_enhanced.py
@@ -10,6 +10,7 @@ Enhanced Analysis Engine
 from __future__ import annotations
 from typing import Dict, Any, Optional
 import logging
+import pandas as pd
 
 from yandexgpt_service import YandexGPTService
 


### PR DESCRIPTION
Add missing pandas and okama imports to resolve NameError exceptions in compare and portfolio commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7eb8d1d-bd5c-4f24-bf66-f39f2c24361a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7eb8d1d-bd5c-4f24-bf66-f39f2c24361a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

