### PR TITLE
Compare portfolio assets with invalid namespace

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1423,7 +1423,8 @@ class OkamaFinanceBot:
                     
                 else:
                     # Regular assets only, use AssetList
-                    asset_list = ok.AssetList(symbols, ccy=currency)
+                    # Use raw parsed tickers (expanded_symbols) for okama, not display descriptions
+                    asset_list = ok.AssetList(expanded_symbols, ccy=currency)
                     self.logger.info("Created AssetList with full available period")
                     
                     # Generate beautiful comparison chart using chart_styles


### PR DESCRIPTION
Use raw tickers for `ok.AssetList` in `/compare` command.

This fixes the "US) is not in allowed assets namespaces" error by preventing display strings with parentheses from being passed to okama.

---
<a href="https://cursor.com/background-agent?bcId=bc-942f7077-4d47-4030-b3e3-dc4f28b8a558">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-942f7077-4d47-4030-b3e3-dc4f28b8a558">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

